### PR TITLE
Allocate memory for the null-terminator in strings as well

### DIFF
--- a/bspwc/main.c
+++ b/bspwc/main.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 			    exit(EXIT_SUCCESS);
                 break;
             case 'c':
-                config_file = malloc(strlen(optarg));
+                config_file = malloc(strlen(optarg) + 1);
                 strcpy(config_file, optarg);
                 break;
             case 's':
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
     // Setup BSPWM related stuff
     if (server.socket_name == NULL)
     {
-        server.socket_name = malloc(strlen(BSPWC_DEFAULT_SOCKET));
+        server.socket_name = malloc(strlen(BSPWC_DEFAULT_SOCKET) + 1);
         strcpy(server.socket_name, BSPWC_DEFAULT_SOCKET);
     }
 


### PR DESCRIPTION
When allocating memory for strings, an extra byte is needed for the null-terminator character `'\0'`. Note that when building with `-D_FORTIFY_SOURCE` enabled, most compilers will catch the issue and warn accordingly:

```
  In file included from /usr/include/string.h:494:0,
                   from ../bspwc/main.c:6:
  In function ‘strcpy’,
      inlined from ‘main’ at ../bspwc/main.c:145:9:
  /usr/include/bits/string_fortified.h:90:10: error: ‘__builtin___memcpy_chk’ writing 18 bytes into a region of size 17 overflows the destination [-Werror=stringop-overflow=]
     return __builtin___strcpy_chk (__dest, __src, __bos (__dest));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This patch fixes this issue.