### PR TITLE
input.c: handle WLR_INPUT_DEVICE_SWITCH

### DIFF
--- a/bspwc/input.c
+++ b/bspwc/input.c
@@ -14,6 +14,8 @@ const char *device_type(enum wlr_input_device_type type)
 		return "tablet tool";
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		return "tablet pad";
+	case WLR_INPUT_DEVICE_SWITCH:
+		return "switch";
 	}
 
 	return "UNKNOWN_DEVICE";


### PR DESCRIPTION
This allows `bspwc` to build properly against the latest `wlroots`.